### PR TITLE
Use regex string compare for notify_on_all_messages_in_buffers

### DIFF
--- a/notify_send.py
+++ b/notify_send.py
@@ -31,6 +31,7 @@ import os
 import subprocess
 import sys
 import time
+import re
 
 
 # Ensure that we are running under WeeChat.
@@ -499,8 +500,9 @@ def notify_on_all_messages_in_buffer(buffer):
     """
     buffer_names = names_for_buffer(buffer)
     for buf in buffers_to_notify_on_all_messages():
-        if buf in buffer_names:
-            return True
+        for n in buffer_names:
+            if re.compile(buf).match(n):
+                return True
     return False
 
 


### PR DESCRIPTION
I use weechat mostly as a Matrix client, and I wanted a simple way of getting notifications from all the different rooms I'm a part of. I'm pretty sure this change won't break anything and it's pretty simple. It also provides an easy way to get notifications for everything, i.e. `notify_on_all_messages_in_buffers = "*"` or everything except for certain buffers with a exclusion pattern.