### PR TITLE
Add two new notification options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 dev
 ---
 
+* Added new option: `auto_close_prior_buffer_notification`. When set
+  to `on`, printing a message in a buffer automatically closes any prior
+  notification associated with that buffer.
 * Added a new option: `replace_buffer_notifications`. When set to `on`,
   notifications sent to a buffer replace any existing notification.
 * Dropped official support for Python 3.8 as [it is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 dev
 ---
 
+* Added a new option: `replace_buffer_notifications`. When set to `on`,
+  notifications sent to a buffer replace any existing notification.
 * Dropped official support for Python 3.8 as [it is
   EOL](https://endoflife.date/python).
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ plugins.var.python.notify_send.XXX YYY` or by using the
   notification bar. Set it to `off` to keep the notification. Default: `on`.
 * `urgency`: Notification urgency (`low`, `normal`, `critical`). Default:
   `normal`.
+* `replace_buffer_notifications`: Instead of generating more than one
+  notification per buffer, replace each buffer's previous one with the
+  latest notification. Default: `off`.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ plugins.var.python.notify_send.XXX YYY` or by using the
 * `replace_buffer_notifications`: Instead of generating more than one
   notification per buffer, replace each buffer's previous one with the
   latest notification. Default: `off`.
+* `auto_close_prior_buffer_notification`: When printing a message in a buffer,
+  automatically close any prior notification associated with that buffer.
+  Default: `off`.
 
 License
 -------

--- a/notify_send.py
+++ b/notify_send.py
@@ -190,6 +190,11 @@ OPTIONS = {
         'off',
         'Instead of generating more than one notification per buffer, '
         'replace each buffer\'s previous one with the latest notification.'
+    ),
+    'auto_close_prior_buffer_notification': (
+        'off',
+        'When printing a message in a buffer, automatically close any prior '
+        'notification associated with that buffer.'
     )
 }
 
@@ -279,6 +284,9 @@ def message_printed_callback(data, buffer, date, tags, is_displayed,
     if notification_should_be_sent(buffer, tags, nick, is_displayed, is_highlight, message):
         notification = prepare_notification(buffer, nick, message)
         send_notification(buffer, notification)
+    elif (i_am_author_of_message(buffer, nick) and
+          auto_close_prior_notification_for_buffer(buffer)):
+        close_notification(buffer)
 
     return weechat.WEECHAT_RC_OK
 
@@ -620,6 +628,13 @@ def replace_notification_for_buffer(buffer):
     return weechat.config_get_plugin('replace_buffer_notifications') == 'on'
 
 
+def auto_close_prior_notification_for_buffer(buffer):
+    """Should a prior notification associated with this buffer be automatically
+    closed?
+    """
+    return weechat.config_get_plugin('auto_close_prior_buffer_notification') == 'on'
+
+
 def prepare_notification(buffer, nick, message):
     """Prepares a notification from the given data."""
     if is_private_message(buffer):
@@ -780,6 +795,29 @@ def send_notification(buffer, notification):
             'Ensure that you have notify-send installed in your system.',
         )
         print(error_message, file=sys.stderr)
+
+
+def close_notification(buffer):
+    """Closes the buffer's last notification."""
+    notification_id = buffer_get_notification_id(buffer)
+
+    # Nothing to do unless there's a non-zero notification_id.
+    if notification_id == '0':
+        return
+
+    # Close the last notification by replacing it with a blank one that
+    # quickly times out.
+    notification = Notification(
+        source=' ',  # single space (not '')
+        message='',
+        icon=weechat.config_get_plugin('icon'),
+        desktop_entry=weechat.config_get_plugin('desktop_entry'),
+        timeout='5',  # 5ms
+        transient=should_notifications_be_transient(),
+        urgency=weechat.config_get_plugin('urgency'),
+        replace_id=notification_id,
+    )
+    send_notification(buffer, notification)
 
 
 if __name__ == '__main__':

--- a/notify_send.py
+++ b/notify_send.py
@@ -29,7 +29,6 @@
 
 from __future__ import print_function
 
-import os
 import re
 import subprocess
 import sys
@@ -186,14 +185,22 @@ OPTIONS = {
     'urgency': (
         'normal',
         'Urgency (low, normal, critical).'
+    ),
+    'replace_buffer_notifications': (
+        'off',
+        'Instead of generating more than one notification per buffer, '
+        'replace each buffer\'s previous one with the latest notification.'
     )
 }
+
+NOTIFICATION_ID_VAR = 'notify_send_notification_id'
 
 
 class Notification(object):
     """A representation of a notification."""
 
-    def __init__(self, source, message, icon, desktop_entry, timeout, transient, urgency):
+    def __init__(self, source, message, icon,
+                 desktop_entry, timeout, transient, urgency, replace_id):
         self.source = source
         self.message = message
         self.icon = icon
@@ -201,6 +208,21 @@ class Notification(object):
         self.timeout = timeout
         self.transient = transient
         self.urgency = urgency
+        self.replace_id = replace_id
+
+
+def buffer_get_notification_id(buffer):
+    """Returns the ID of the last notification sent for a buffer,
+    or '0' if none have been sent.
+    """
+    property = 'localvar_' + NOTIFICATION_ID_VAR
+    return weechat.buffer_get_string(buffer, property) or '0'
+
+
+def buffer_set_notification_id(buffer, notification_id):
+    """Saves the notification ID in a local buffer variable."""
+    property = 'localvar_set_' + NOTIFICATION_ID_VAR
+    weechat.buffer_set(buffer, property, notification_id)
 
 
 def default_value_of(option):
@@ -256,7 +278,7 @@ def message_printed_callback(data, buffer, date, tags, is_displayed,
 
     if notification_should_be_sent(buffer, tags, nick, is_displayed, is_highlight, message):
         notification = prepare_notification(buffer, nick, message)
-        send_notification(notification)
+        send_notification(buffer, notification)
 
     return weechat.WEECHAT_RC_OK
 
@@ -593,6 +615,11 @@ def hide_message_in_buffer(buffer):
     return False
 
 
+def replace_notification_for_buffer(buffer):
+    """Should a new notification replace a buffer's previous notification?"""
+    return weechat.config_get_plugin('replace_buffer_notifications') == 'on'
+
+
 def prepare_notification(buffer, nick, message):
     """Prepares a notification from the given data."""
     if is_private_message(buffer):
@@ -621,7 +648,14 @@ def prepare_notification(buffer, nick, message):
     transient = should_notifications_be_transient()
     urgency = weechat.config_get_plugin('urgency')
 
-    return Notification(source, message, icon, desktop_entry, timeout, transient, urgency)
+    if replace_notification_for_buffer(buffer):
+        replace_id = buffer_get_notification_id(buffer)
+    else:
+        # Specify '0' to generate a new notification.
+        replace_id = '0'
+
+    return Notification(source, message, icon,
+                        desktop_entry, timeout, transient, urgency, replace_id)
 
 
 def should_notifications_be_transient():
@@ -697,9 +731,9 @@ def escape_slashes(message):
     return message.replace('\\', r'\\')
 
 
-def send_notification(notification):
+def send_notification(buffer, notification):
     """Sends the given notification to the user."""
-    notify_cmd = ['notify-send', '--app-name', 'weechat']
+    notify_cmd = ['notify-send', '--print-id', '--app-name', 'weechat']
     if notification.icon:
         notify_cmd += ['--icon', notification.icon]
     if notification.desktop_entry:
@@ -710,6 +744,8 @@ def send_notification(notification):
         notify_cmd += ['--hint', 'int:transient:1']
     if notification.urgency:
         notify_cmd += ['--urgency', notification.urgency]
+    if notification.replace_id != '0':
+        notify_cmd += ['--replace-id', notification.replace_id]
     # The "im.received" category means "A received instant message
     # notification".
     notify_cmd += ['--category', 'im.received']
@@ -724,25 +760,26 @@ def send_notification(notification):
         notification.message
     ]
 
-    # Prevent notify-send from messing up the WeeChat screen when occasionally
-    # emitting assertion messages by redirecting the output to /dev/null (users
-    # would need to run /redraw to fix the screen).
-    # In Python < 3.3, there is no subprocess.DEVNULL, so we have to use a
-    # workaround.
-    with open(os.devnull, 'wb') as devnull:
+    try:
+        output = subprocess.check_output(notify_cmd,
+                                         stderr=subprocess.STDOUT,
+                                         universal_newlines=True)
+
+        notification_id = output.strip('\n')
         try:
-            subprocess.check_call(
-                notify_cmd,
-                stderr=subprocess.STDOUT,
-                stdout=devnull,
-            )
-        except Exception as ex:
-            error_message = '{} (reason: {!r}). {}'.format(
-                'Failed to send the notification via notify-send',
-                '{}: {}'.format(ex.__class__.__name__, ex),
-                'Ensure that you have notify-send installed in your system.',
-            )
-            print(error_message, file=sys.stderr)
+            _ = int(notification_id)
+        except ValueError:
+            notification_id = '0'
+        if notification_id != notification.replace_id:
+            buffer_set_notification_id(buffer, notification_id)
+
+    except Exception as ex:
+        error_message = '{} (reason: {!r}). {}'.format(
+            'Failed to send the notification via notify-send',
+            '{}: {}'.format(ex.__class__.__name__, ex),
+            'Ensure that you have notify-send installed in your system.',
+        )
+        print(error_message, file=sys.stderr)
 
 
 if __name__ == '__main__':

--- a/notify_send_tests.py
+++ b/notify_send_tests.py
@@ -26,7 +26,6 @@
 # SOFTWARE.
 #
 
-import os
 import sys
 import unittest
 
@@ -63,8 +62,9 @@ from notify_send import shorten_message
 
 def new_notification(source='source', message='message', icon='icon.png',
                      desktop_entry='weechat', timeout=5000, transient=True,
-                     urgency='normal'):
-    return Notification(source, message, icon, desktop_entry, timeout, transient, urgency)
+                     urgency='normal', replace_id='0'):
+    return Notification(source, message, icon,
+                        desktop_entry, timeout, transient, urgency, replace_id)
 
 
 def set_config_option(option, value):
@@ -144,6 +144,7 @@ class TestsBase(unittest.TestCase):
         set_config_option('timeout', '0')
         set_config_option('transient', 'on')
         set_config_option('urgency', '')
+        set_config_option('replace_buffer_notifications', 'off')
 
         # Mimic the behavior of weechat.buffer_get_string() by returning the
         # empty string by default.
@@ -986,6 +987,32 @@ class PrepareNotificationTests(TestsBase):
 
         self.assertEqual(notification.message, 'hello')
 
+    def test_notification_has_correct_replace_id_when_replace_buffer_notifications_on(self):
+        BUFFER = 'buffer'
+        set_buffer_string(BUFFER, 'localvar_notify_send_notification_id', '5555')
+        set_config_option('replace_buffer_notifications', 'on')
+
+        notification = self.prepare_notification(BUFFER, message='hello')
+
+        self.assertEqual(notification.replace_id, '5555')
+
+    def test_notification_has_correct_replace_id_when_replace_buffer_notifications_off(self):
+        BUFFER = 'buffer'
+        set_buffer_string(BUFFER, 'localvar_notify_send_notification_id', '5555')
+        set_config_option('replace_buffer_notifications', 'off')
+
+        notification = self.prepare_notification(BUFFER, message='hello')
+
+        self.assertEqual(notification.replace_id, '0')
+
+    def test_notification_has_correct_replace_id_when_buffer_var_not_set(self):
+        BUFFER = 'buffer'
+        set_config_option('replace_buffer_notifications', 'on')
+
+        notification = self.prepare_notification(BUFFER, message='hello')
+
+        self.assertEqual(notification.replace_id, '0')
+
 
 class NickSeparatorTests(TestsBase):
     """Tests for nick_separator()."""
@@ -1069,6 +1096,7 @@ class SendNotificationTests(TestsBase):
         self.addCleanup(patcher.stop)
 
     def test_calls_correct_command_when_all_notification_parameters_are_set(self):
+        BUFFER = 'buffer'
         notification = new_notification(
             source='source',
             message='message',
@@ -1076,89 +1104,139 @@ class SendNotificationTests(TestsBase):
             desktop_entry='weechat',
             timeout=5000,
             transient=True,
-            urgency='normal'
+            urgency='normal',
+            replace_id='666'
         )
 
-        send_notification(notification)
+        send_notification(BUFFER, notification)
 
-        class AnyDevNullStream:
-            def __eq__(self, other):
-                return other.name == os.devnull
-
-        self.subprocess.check_call.assert_called_once_with(
+        self.subprocess.check_output.assert_called_once_with(
             [
                 'notify-send',
+                '--print-id',
                 '--app-name', 'weechat',
                 '--icon', 'icon.png',
                 '--hint', 'string:desktop-entry:weechat',
                 '--expire-time', '5000',
                 '--hint', 'int:transient:1',
                 '--urgency', 'normal',
+                '--replace-id', '666',
                 '--category', 'im.received',
                 '--',
                 'source',
                 'message'
             ],
             stderr=self.subprocess.STDOUT,
-            stdout=AnyDevNullStream()
+            universal_newlines=True
         )
 
     def test_source_is_set_to_hyphen_when_source_is_empty(self):
+        BUFFER = 'buffer'
         notification = new_notification(source='')
 
-        send_notification(notification)
+        send_notification(BUFFER, notification)
 
-        notify_cmd = self.subprocess.check_call.call_args[0][0]
+        notify_cmd = self.subprocess.check_output.call_args[0][0]
         self.assertIn('-', notify_cmd)
 
     def test_does_not_include_icon_in_command_when_icon_is_not_set(self):
+        BUFFER = 'buffer'
         notification = new_notification(icon='')
 
-        send_notification(notification)
+        send_notification(BUFFER, notification)
 
-        notify_cmd = self.subprocess.check_call.call_args[0][0]
+        notify_cmd = self.subprocess.check_output.call_args[0][0]
         self.assertNotIn('--icon', notify_cmd)
 
     def test_does_not_include_desktop_entry_in_command_when_it_is_not_set(self):
+        BUFFER = 'buffer'
         notification = new_notification(desktop_entry='')
 
-        send_notification(notification)
+        send_notification(BUFFER, notification)
 
-        notify_cmd = self.subprocess.check_call.call_args[0][0]
+        notify_cmd = self.subprocess.check_output.call_args[0][0]
         self.assertNotIn('desktop-entry', notify_cmd)
 
     def test_does_not_include_expire_time_in_command_when_timeout_is_not_set(self):
+        BUFFER = 'buffer'
         notification = new_notification(timeout='')
 
-        send_notification(notification)
+        send_notification(BUFFER, notification)
 
-        notify_cmd = self.subprocess.check_call.call_args[0][0]
+        notify_cmd = self.subprocess.check_output.call_args[0][0]
         self.assertNotIn('--expire-time', notify_cmd)
 
     def test_does_not_include_transient_hint_in_command_when_transient_is_off(self):
+        BUFFER = 'buffer'
         notification = new_notification(transient=False)
 
-        send_notification(notification)
+        send_notification(BUFFER, notification)
 
-        notify_cmd = self.subprocess.check_call.call_args[0][0]
+        notify_cmd = self.subprocess.check_output.call_args[0][0]
         self.assertNotIn('int:transient:1', notify_cmd)
 
     def test_does_not_include_urgency_in_command_when_urgency_is_not_set(self):
+        BUFFER = 'buffer'
         notification = new_notification(urgency='')
 
-        send_notification(notification)
+        send_notification(BUFFER, notification)
 
-        notify_cmd = self.subprocess.check_call.call_args[0][0]
+        notify_cmd = self.subprocess.check_output.call_args[0][0]
         self.assertNotIn('--urgency', notify_cmd)
 
+    def test_does_not_include_replace_id_in_command_when_replace_id_is_zero(self):
+        BUFFER = 'buffer'
+        notification = new_notification(replace_id='0')
+
+        send_notification(BUFFER, notification)
+
+        notify_cmd = self.subprocess.check_output.call_args[0][0]
+        self.assertNotIn('--replace-id', notify_cmd)
+
     def test_prints_error_message_when_notification_sending_fails(self):
-        self.subprocess.check_call.side_effect = OSError(
+        BUFFER = 'buffer'
+        self.subprocess.check_output.side_effect = OSError(
             'No such file or directory: notify-send'
         )
 
-        send_notification(new_notification())
+        send_notification(BUFFER, new_notification())
 
         self.assertIn(
             'OSError: No such file or directory',
             self.print_mock.call_args[0][0]
+        )
+
+    def test_notification_id_is_saved_when_replace_id_differs(self):
+        BUFFER = 'buffer'
+        notification = new_notification(replace_id='1234')
+        self.subprocess.check_output.return_value = '4321\n'
+
+        send_notification(BUFFER, notification)
+
+        weechat.buffer_set.assert_called_once_with(
+            BUFFER,
+            'localvar_set_notify_send_notification_id',
+            '4321'
+        )
+
+    def test_notification_id_is_not_saved_when_replace_id_matches(self):
+        BUFFER = 'buffer'
+        notification = new_notification(replace_id='1234')
+        self.subprocess.check_output.return_value = '1234\n'
+
+        send_notification(BUFFER, notification)
+
+        weechat.buffer_set.assert_not_called()
+
+    def test_notification_id_is_reset_when_an_error_occurs(self):
+        BUFFER = 'buffer'
+        notification = new_notification(replace_id='1234')
+        self.subprocess.check_output.return_value = '1234xxx\n'
+
+        send_notification(BUFFER, notification)
+
+        weechat.buffer_set.assert_called_once_with(
+            BUFFER,
+            'localvar_set_notify_send_notification_id',
+            '0'
         )

--- a/notify_send_tests.py
+++ b/notify_send_tests.py
@@ -57,6 +57,7 @@ from notify_send import notify_on_all_messages_in_buffer
 from notify_send import notify_on_messages_that_match
 from notify_send import prepare_notification
 from notify_send import send_notification
+from notify_send import close_notification
 from notify_send import shorten_message
 
 
@@ -145,6 +146,7 @@ class TestsBase(unittest.TestCase):
         set_config_option('transient', 'on')
         set_config_option('urgency', '')
         set_config_option('replace_buffer_notifications', 'off')
+        set_config_option('auto_close_prior_buffer_notification', 'off')
 
         # Mimic the behavior of weechat.buffer_get_string() by returning the
         # empty string by default.
@@ -222,6 +224,16 @@ class MessagePrintedCallbackTests(TestsBase):
         self.send_notification = patcher.start()
         self.addCleanup(patcher.stop)
 
+        # Mock i_am_author_of_message().
+        patcher = mock.patch('notify_send.i_am_author_of_message')
+        self.i_am_author_of_message = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        # Mock close_notification().
+        patcher = mock.patch('notify_send.close_notification')
+        self.close_notification = patcher.start()
+        self.addCleanup(patcher.stop)
+
     def message_printed_callback(self, data=None, buffer='buffer', date=None,
                                  tags='', is_displayed='1', is_highlight='0',
                                  prefix='prefix', message='message'):
@@ -242,6 +254,42 @@ class MessagePrintedCallbackTests(TestsBase):
 
         rc = self.message_printed_callback()
 
+        self.assertTrue(self.notification_should_be_sent.called)
+        self.assertFalse(self.send_notification.called)
+        self.assertEqual(rc, weechat.WEECHAT_RC_OK)
+
+    def test_closes_notification_when_auto_close_prior_buffer_notification_is_on(self):
+        self.notification_should_be_sent.return_value = False
+        self.i_am_author_of_message.return_value = True
+        set_config_option('auto_close_prior_buffer_notification', 'on')
+
+        rc = self.message_printed_callback()
+
+        self.assertTrue(self.close_notification.called)
+        self.assertTrue(self.notification_should_be_sent.called)
+        self.assertFalse(self.send_notification.called)
+        self.assertEqual(rc, weechat.WEECHAT_RC_OK)
+
+    def test_does_not_close_notification_when_auto_close_prior_buffer_notification_is_off(self):
+        self.notification_should_be_sent.return_value = False
+        self.i_am_author_of_message.return_value = True
+        set_config_option('auto_close_prior_buffer_notification', 'off')
+
+        rc = self.message_printed_callback()
+
+        self.assertFalse(self.close_notification.called)
+        self.assertTrue(self.notification_should_be_sent.called)
+        self.assertFalse(self.send_notification.called)
+        self.assertEqual(rc, weechat.WEECHAT_RC_OK)
+
+    def test_does_not_close_notification_when_i_am_not_author(self):
+        self.notification_should_be_sent.return_value = False
+        self.i_am_author_of_message.return_value = False
+        set_config_option('auto_close_prior_buffer_notification', 'on')
+
+        rc = self.message_printed_callback()
+
+        self.assertFalse(self.close_notification.called)
         self.assertTrue(self.notification_should_be_sent.called)
         self.assertFalse(self.send_notification.called)
         self.assertEqual(rc, weechat.WEECHAT_RC_OK)
@@ -1239,4 +1287,76 @@ class SendNotificationTests(TestsBase):
             BUFFER,
             'localvar_set_notify_send_notification_id',
             '0'
+        )
+
+
+class CloseNotificationTests(TestsBase):
+    """Tests for close_notification()."""
+
+    def setUp(self):
+        super(CloseNotificationTests, self).setUp()
+
+        # Mock subprocess.
+        patcher = mock.patch('notify_send.subprocess')
+        self.subprocess = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        # Mock print.
+        if sys.version_info.major == 3:
+            patcher = mock.patch('builtins.print')
+        else:
+            patcher = mock.patch('notify_send.print')
+        self.print_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_calls_correct_command_when_notification_should_be_closed(self):
+        BUFFER = 'buffer'
+        set_buffer_string(BUFFER, 'localvar_notify_send_notification_id', '5678')
+
+        close_notification(BUFFER)
+
+        self.subprocess.check_output.assert_called_once_with(
+            [
+                'notify-send',
+                '--print-id',
+                '--app-name', 'weechat',
+                '--expire-time', '5',
+                '--hint', 'int:transient:1',
+                '--replace-id', '5678',
+                '--category', 'im.received',
+                '--',
+                ' ',
+                ''
+            ],
+            stderr=self.subprocess.STDOUT,
+            universal_newlines=True
+        )
+
+    def test_does_not_close_notification_when_notification_id_is_zero(self):
+        BUFFER = 'buffer'
+        set_buffer_string(BUFFER, 'localvar_notify_send_notification_id', '0')
+
+        close_notification(BUFFER)
+
+        self.subprocess.check_output.assert_not_called()
+
+    def test_does_not_close_notification_when_notification_id_is_not_set(self):
+        BUFFER = 'buffer'
+
+        close_notification(BUFFER)
+
+        self.subprocess.check_output.assert_not_called()
+
+    def test_prints_error_message_when_closing_notification_fails(self):
+        BUFFER = 'buffer'
+        set_buffer_string(BUFFER, 'localvar_notify_send_notification_id', '5678')
+        self.subprocess.check_output.side_effect = OSError(
+            'No such file or directory: notify-send'
+        )
+
+        close_notification(BUFFER)
+
+        self.assertIn(
+            'OSError: No such file or directory: notify-send',
+            self.print_mock.call_args[0][0]
         )


### PR DESCRIPTION
This pull request proposes two new options that, together with existing options, provide a way to configure notifications for a specific user experience. The new options are fully described in the commit messages, and the following settings establish the experience:

python.notify_send.timeout = "0"
- Make the notifications persistent. I don't want to miss a notification because I was away getting coffee.

python.notify_send.hide_messages_in_buffers_that_match = ".*"
- Just tell me I'm being pinged in a channel or by DM. I don't need to see the actual message, especially when it's often something useless like "Hello, how are you?"

python.notify_send.replace_buffer_notifications = "on" (new option)
- Basically this means "one notification per buffer." If I receive multiple pings or DMs from somebody, I don't need to see multiple notifications. I just need to know I'm being pinged, and the buffer name tells me where to look for the messages.

python.notify_send.auto_close_prior_buffer_notification = "on" (new option)
- Close the notification when I respond, which essentially clears the otherwise persistent notification. That way, the only time I need to manually clear a notification is when the immediate conversation is over and mine was not the last response.

